### PR TITLE
Fix PyPI trusted publishers authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,8 @@ jobs:
     name: Deploy to Test PyPI
     runs-on: ubuntu-latest
     needs: [validate, build]
+    permissions:
+      id-token: write
     if: |
       (startsWith(github.ref, 'refs/tags/v') && needs.validate.outputs.is_prerelease == 'true') ||
       (github.event_name == 'workflow_dispatch' && inputs.deploy_to_test_pypi)
@@ -95,7 +97,6 @@ jobs:
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
 
@@ -103,6 +104,8 @@ jobs:
     name: Deploy to PyPI
     runs-on: ubuntu-latest
     needs: [validate, build]
+    permissions:
+      id-token: write
     if: |
       (startsWith(github.ref, 'refs/tags/v') && needs.validate.outputs.is_prerelease == 'false') ||
       (github.event_name == 'workflow_dispatch' && inputs.deploy_to_prod_pypi)
@@ -115,8 +118,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   docker:
     name: Build Docker Image


### PR DESCRIPTION
- Remove API token passwords that were disabling trusted publishing
- Add id-token: write permissions to PyPI deployment jobs
- Fixes "explicit password was also set, disabling Trusted Publishing" error

🤖 Generated with [Claude Code](https://claude.ai/code)